### PR TITLE
Add dynamic log metadata support

### DIFF
--- a/src/main/java/org/betterbox/elasticBuffer/ElasticBuffer.java
+++ b/src/main/java/org/betterbox/elasticBuffer/ElasticBuffer.java
@@ -20,8 +20,11 @@ import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import javax.net.ssl.*;
 import java.security.SecureRandom;
@@ -111,18 +114,30 @@ public class ElasticBuffer extends JavaPlugin {
 
 
     public synchronized void receiveLog(String log, String level, String pluginName,String transactionID,String playerName, String uuid) {
-        long logTimestamp = System.currentTimeMillis();
-        logBuffer.add(log, level, pluginName,logTimestamp,transactionID,playerName,uuid,0);
-        elasticBufferPluginLogger.log(ElasticBufferPluginLogger.LogLevel.DEBUG, "Received log: " + log+", pluginName: "+pluginName+". level: "+level);
+        receiveLog(log, level, pluginName, transactionID, playerName, uuid, 0.0, Collections.emptyMap());
     }
     public synchronized void receiveLog(String log, String level, String pluginName,String transactionID) {
-        long logTimestamp = System.currentTimeMillis();
-        logBuffer.add(log, level, pluginName,logTimestamp,transactionID,null,null,0);
-        elasticBufferPluginLogger.log(ElasticBufferPluginLogger.LogLevel.DEBUG, "Received log: " + log+", pluginName: "+pluginName+". level: "+level);
+        receiveLog(log, level, pluginName, transactionID, null, null, 0.0, Collections.emptyMap());
     }
     public synchronized void receiveLog(String log, String level, String pluginName,String transactionID,String playerName, String uuid, double keyValue) {
+        Map<String, Object> fields = new HashMap<>();
+        fields.put("keyValue", keyValue);
+        receiveLog(log, level, pluginName, transactionID, playerName, uuid, keyValue, fields);
+    }
+    public synchronized void receiveLog(String log, String level, String pluginName,String transactionID,String playerName, String uuid, Map<String, Object> additionalFields) {
+        receiveLog(log, level, pluginName, transactionID, playerName, uuid, 0.0, additionalFields);
+    }
+
+    public synchronized void receiveLog(String log, String level, String pluginName,String transactionID,String playerName, String uuid, double keyValue, Map<String, Object> additionalFields) {
         long logTimestamp = System.currentTimeMillis();
-        logBuffer.add(log, level, pluginName,logTimestamp,transactionID,playerName,uuid,keyValue);
+        Map<String, Object> safeFields = additionalFields != null ? new HashMap<>(additionalFields) : new HashMap<>();
+        Object keyValueFromFields = safeFields.remove("keyValue");
+        double resolvedKeyValue = keyValue;
+        if (keyValueFromFields instanceof Number) {
+            resolvedKeyValue = ((Number) keyValueFromFields).doubleValue();
+        }
+
+        logBuffer.add(log, level, pluginName,logTimestamp,transactionID,playerName,uuid,resolvedKeyValue, safeFields);
         elasticBufferPluginLogger.log(ElasticBufferPluginLogger.LogLevel.DEBUG, "Received log: " + log+", pluginName: "+pluginName+". level: "+level);
     }
 
@@ -266,11 +281,13 @@ public class ElasticBuffer extends JavaPlugin {
     }
 
     private String buildNdjsonChunk(LogEntry logEntry, String messageChunk) {
-        String sanitizedMessage = sanitizeMessage(messageChunk);
+        String sanitizedMessage = sanitizeValue(messageChunk);
         StringBuilder ndjsonBuilder = new StringBuilder();
         ndjsonBuilder.append("{\"index\":{}}\n");
+
+        ndjsonBuilder.append("{");
         ndjsonBuilder.append(String.format(
-                "{\"timestamp\":\"%s\",\"plugin\":\"%s\",\"transactionID\":\"%s\",\"level\":\"%s\",\"message\":\"%s\",\"playerName\":\"%s\",\"uuid\":\"%s\",\"serverName\":\"%s\",\"keyValue\":\"%.5f\"}\n",
+                "\"timestamp\":\"%s\",\"plugin\":\"%s\",\"transactionID\":\"%s\",\"level\":\"%s\",\"message\":\"%s\",\"playerName\":\"%s\",\"uuid\":\"%s\",\"serverName\":\"%s\",\"keyValue\":\"%.5f\"",
                 java.time.format.DateTimeFormatter.ISO_INSTANT.format(java.time.Instant.ofEpochMilli(logEntry.getTimestamp())),
                 logEntry.getPluginName(),
                 logEntry.getTransactionID(),
@@ -281,10 +298,27 @@ public class ElasticBuffer extends JavaPlugin {
                 elasticBufferConfigManager.getServerName(),
                 logEntry.getKeyValue()
         ));
+
+        for (Map.Entry<String, Object> entry : logEntry.getAdditionalFields().entrySet()) {
+            if (entry.getKey() == null || entry.getValue() == null) {
+                continue;
+            }
+            ndjsonBuilder.append(",\"").append(sanitizeValue(entry.getKey())).append("\":");
+            ndjsonBuilder.append(formatAdditionalValue(entry.getValue()));
+        }
+
+        ndjsonBuilder.append("}\n");
         return ndjsonBuilder.toString();
     }
-    private String sanitizeMessage(String message) {
-        // Usuwanie znaku przejścia do nowej linii i cudzysłowu
+    private String sanitizeValue(String message) {
+        // Usuwanie cudzysłowów, aby nie zepsuć formatu JSON
         return message.replace("\"", "");
+    }
+
+    private String formatAdditionalValue(Object value) {
+        if (value instanceof Number || value instanceof Boolean) {
+            return value.toString();
+        }
+        return "\"" + sanitizeValue(String.valueOf(value)) + "\"";
     }
 }

--- a/src/main/java/org/betterbox/elasticBuffer/ElasticBufferAPI.java
+++ b/src/main/java/org/betterbox/elasticBuffer/ElasticBufferAPI.java
@@ -1,5 +1,8 @@
 package org.betterbox.elasticBuffer;
-import org.betterbox.elasticBuffer.ElasticBuffer;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 public class ElasticBufferAPI {
     private final ElasticBuffer elasticBuffer;
@@ -11,19 +14,27 @@ public class ElasticBufferAPI {
     }
 
     public void log(String message, String level, String pluginName, String transactionID,String playerName,String uuid) {
-        if (elasticBuffer != null) {
-            elasticBuffer.receiveLog(message, level, pluginName,transactionID,playerName,uuid);
-        }
+        log(message, level, pluginName, transactionID, playerName, uuid, Collections.emptyMap());
     }
     public void log(String message, String level, String pluginName, String transactionID) {
-        if (elasticBuffer != null) {
-            elasticBuffer.receiveLog(message, level, pluginName,transactionID);
-        }
+        log(message, level, pluginName, transactionID, "N/A", "N/A", Collections.emptyMap());
     }
     public void log(String message, String level, String pluginName, String transactionID,String playerName,String uuid,double keyValue) {
-        if (elasticBuffer != null) {
-            elasticBuffer.receiveLog(message, level, pluginName,transactionID,playerName,uuid,keyValue);
-        }
+        Map<String,Object> additionalFields = new HashMap<>();
+        additionalFields.put("keyValue", keyValue);
+        log(message, level, pluginName, transactionID, playerName, uuid, additionalFields);
 
+    }
+
+    public void log(String message,
+                    String level,
+                    String pluginName,
+                    String transactionID,
+                    String playerName,
+                    String uuid,
+                    Map<String, Object> additionalFields) {
+        if (elasticBuffer != null) {
+            elasticBuffer.receiveLog(message, level, pluginName, transactionID, playerName, uuid, additionalFields);
+        }
     }
 }

--- a/src/main/java/org/betterbox/elasticBuffer/EventLogger.java
+++ b/src/main/java/org/betterbox/elasticBuffer/EventLogger.java
@@ -34,6 +34,8 @@ import org.bukkit.plugin.Plugin;
 
 import javax.management.monitor.Monitor;
 import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
@@ -513,6 +515,17 @@ public class EventLogger implements Listener {
                         event.getEntity().getLocation().toString()
                 );
 
+                Map<String, Object> additionalFields = new HashMap<>();
+                additionalFields.put("distance", distance);
+                additionalFields.put("weaponUsed", weaponUsed);
+                additionalFields.put("attackerPing", attacker.getPing());
+                additionalFields.put("finalDamage", event.getFinalDamage());
+
+                if (event.getEntity() instanceof Player) {
+                    Player victimPlayer = (Player) event.getEntity();
+                    additionalFields.put("victimPing", victimPlayer.getPing());
+                }
+
                 api.log(
                         logMessage,
                         "INFO",
@@ -520,7 +533,7 @@ public class EventLogger implements Listener {
                         null,
                         attacker.getName(),
                         attacker.getUniqueId().toString(),
-                        distance
+                        additionalFields
                 );
             }
         });
@@ -588,10 +601,19 @@ public class EventLogger implements Listener {
         double difference = newBalance - oldBalance;
 
         // Logowanie zmiany balansu
+        Map<String, Object> balanceChangeFields = new HashMap<>();
+        balanceChangeFields.put("difference", difference);
+        balanceChangeFields.put("oldBalance", oldBalance);
+        balanceChangeFields.put("newBalance", newBalance);
+
         api.log("balance changed by " + difference,
-                "INFO", "Economy", null, playerName, event.getPlayer().getUniqueId().toString(), difference);
+                "INFO", "Economy", null, playerName, event.getPlayer().getUniqueId().toString(), balanceChangeFields);
+
+        Map<String, Object> balanceStateFields = new HashMap<>();
+        balanceStateFields.put("balance", newBalance);
+
         api.log("Player " + playerName + " balance: " + newBalance,
-                "INFO", "Economy", null, playerName, event.getPlayer().getUniqueId().toString(), newBalance);
+                "INFO", "Economy", null, playerName, event.getPlayer().getUniqueId().toString(), balanceStateFields);
     }
 
 }

--- a/src/main/java/org/betterbox/elasticBuffer/LogBuffer.java
+++ b/src/main/java/org/betterbox/elasticBuffer/LogBuffer.java
@@ -2,6 +2,7 @@ package org.betterbox.elasticBuffer;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 public class LogBuffer {
     private final List<LogEntry> buffer;  // Lista do przechowywania logów jako obiekty LogEntry
@@ -15,8 +16,8 @@ public class LogBuffer {
      * @param log Treść logu do dodania.
      * @param level Poziom logowania.
      */
-    public synchronized void add(String log, String level, String pluginName, long timestamp,String transactionID,String playerName,String uuid, double keyValue) {
-        buffer.add(new LogEntry(log, level, pluginName, timestamp,transactionID,playerName,uuid,keyValue));
+    public synchronized void add(String log, String level, String pluginName, long timestamp,String transactionID,String playerName,String uuid, double keyValue, Map<String, Object> additionalFields) {
+        buffer.add(new LogEntry(log, level, pluginName, timestamp,transactionID,playerName,uuid,keyValue, additionalFields));
     }
 
     /**

--- a/src/main/java/org/betterbox/elasticBuffer/LogEntry.java
+++ b/src/main/java/org/betterbox/elasticBuffer/LogEntry.java
@@ -1,6 +1,9 @@
 package org.betterbox.elasticBuffer;
 
 import java.util.UUID;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 public class LogEntry {
     private final String message;
@@ -11,7 +14,8 @@ public class LogEntry {
     private final String playerName;
     private final String uuid;
     private final double keyValue;
-    public LogEntry(String message, String level,String pluginName, long timestamp,String transactionID,String playerName, String uuid, double keyValue) {
+    private final Map<String, Object> additionalFields;
+    public LogEntry(String message, String level,String pluginName, long timestamp,String transactionID,String playerName, String uuid, double keyValue, Map<String, Object> additionalFields) {
         this.message = message;
         this.level = level;
         this.timestamp = timestamp;
@@ -20,6 +24,7 @@ public class LogEntry {
         this.playerName = (playerName != null) ? playerName : "N/A";
         this.uuid = (uuid != null) ? uuid : "N/A";
         this.keyValue = keyValue;
+        this.additionalFields = additionalFields != null ? Collections.unmodifiableMap(new HashMap<>(additionalFields)) : Collections.emptyMap();
     }
     public String getMessage() {
         return message;
@@ -42,6 +47,7 @@ public class LogEntry {
     public double getKeyValue() {
         return keyValue;
     }
+    public Map<String, Object> getAdditionalFields() { return additionalFields; }
 
     @Override
     public String toString() {


### PR DESCRIPTION
## Summary
- allow log entries to include arbitrary metadata fields and propagate them to the NDJSON payload
- capture additional combat context (distance, weapon, ping) using the new metadata support
- update balance logging to send structured amounts rather than a single numeric slot

## Testing
- mvn -q -DskipTests package *(fails: unable to download maven-resources-plugin due to 403 from Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dfbfe32f88326a59b5b30fccc6c7f)