### PR TITLE
Add modular PvP anti-cheat command system

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,28 @@ Configurable connection details - also works with local Elastic/Kibana without s
 How to use it?
 https://jitpack.io/#Grzybol/ElasticBuffer
 [![](https://jitpack.io/v/Grzybol/ElasticBuffer.svg)](https://jitpack.io/#Grzybol/ElasticBuffer)
+
+### Anti-cheat module
+
+The plugin now ships with a modular anti-cheat reaction system aimed at PvP checks (reach, KillAura, velocity and more). Every
+check type is registered through the `AntiCheatManager` so custom checks can be plugged in without touching the core.
+
+Configuration example:
+
+```yaml
+anti-cheat:
+  enabled: true
+  violation-history-seconds: 120
+  thresholds:
+    - severityMin: 5
+      countMin: 2
+      windowSeconds: 45
+      command: "warn %player_name% [Reach] severity=%severity% count=%count%"
+    - severityMin: 7
+      countMin: 3
+      windowSeconds: 90
+      command: "kick %player_name% Excessive violations (%check_type%)"
+```
+
+Supported placeholders: `%player_name%`, `%player_uuid%`, `%player_ip%`, `%check_type%`, `%severity%`, `%count%`. Commands fire as
+console once the moving window meets both severity and count thresholds, and multiple rules can be configured to chain actions.

--- a/pom.xml
+++ b/pom.xml
@@ -139,5 +139,39 @@
             <version>2.20.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>enable-tests</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.0.0-M9</version>
+                        <configuration>
+                            <useModulePath>false</useModulePath>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/src/main/java/org/betterbox/elasticBuffer/ElasticBuffer.java
+++ b/src/main/java/org/betterbox/elasticBuffer/ElasticBuffer.java
@@ -32,6 +32,10 @@ import java.security.cert.X509Certificate;
 import java.util.logging.Handler;
 import java.util.logging.Logger;
 
+import org.betterbox.elasticBuffer.anticheat.AntiCheatManager;
+import org.betterbox.elasticBuffer.anticheat.CheckType;
+import org.betterbox.elasticBuffer.anticheat.SimpleAntiCheatCheck;
+
 public class ElasticBuffer extends JavaPlugin {
     private LogBuffer logBuffer;
     private final int interval = 1200; // 60 seconds * 20 TPS
@@ -42,6 +46,7 @@ public class ElasticBuffer extends JavaPlugin {
     private CustomLogHandler customLogHandler;
     private ServerEventLogger serverEventLogger;
     private CustomConsoleInjector consoleInjector;
+    private AntiCheatManager antiCheatManager;
 
     @Override
     public void onEnable() {
@@ -58,6 +63,8 @@ public class ElasticBuffer extends JavaPlugin {
         Set<ElasticBufferPluginLogger.LogLevel> defaultLogLevels = EnumSet.of(ElasticBufferPluginLogger.LogLevel.INFO, ElasticBufferPluginLogger.LogLevel.WARNING, ElasticBufferPluginLogger.LogLevel.ERROR);
         elasticBufferPluginLogger = new ElasticBufferPluginLogger(getDataFolder().getAbsolutePath(), defaultLogLevels,this);
         elasticBufferConfigManager = new ElasticBufferConfigManager(this, elasticBufferPluginLogger, getDataFolder().getAbsolutePath());
+        antiCheatManager = new AntiCheatManager(this, elasticBufferConfigManager, elasticBufferPluginLogger);
+        registerDefaultChecks();
         logBuffer = new LogBuffer();
         getServer().getScheduler().runTaskTimerAsynchronously(this, this::sendLogs, interval, interval);
         elasticBufferPluginLogger.log(ElasticBufferPluginLogger.LogLevel.INFO, "ElasticBufferAPI registered with ServicesManager");
@@ -108,6 +115,16 @@ public class ElasticBuffer extends JavaPlugin {
             return (ElasticBuffer) plugin;
         }
         return null; // Zwróć null, jeśli instancja nie jest dostępna
+    }
+
+    public AntiCheatManager getAntiCheatManager() {
+        return antiCheatManager;
+    }
+
+    private void registerDefaultChecks() {
+        antiCheatManager.registerCheck(new SimpleAntiCheatCheck("Reach", CheckType.REACH, 5.0));
+        antiCheatManager.registerCheck(new SimpleAntiCheatCheck("KillAura", CheckType.KILLAURA, 6.0));
+        antiCheatManager.registerCheck(new SimpleAntiCheatCheck("Velocity", CheckType.VELOCITY, 4.0));
     }
 
 

--- a/src/main/java/org/betterbox/elasticBuffer/ElasticBufferConfigManager.java
+++ b/src/main/java/org/betterbox/elasticBuffer/ElasticBufferConfigManager.java
@@ -9,6 +9,8 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.*;
 
+import org.betterbox.elasticBuffer.anticheat.AntiCheatThresholdRule;
+
 public class ElasticBufferConfigManager {
     private JavaPlugin plugin;
     private final ElasticBufferPluginLogger elasticBufferPluginLogger;
@@ -20,6 +22,9 @@ public class ElasticBufferConfigManager {
     private String webhookURL,apiKey,indexPattern;
     private String truststorePath, truststorePassword,serverName="default-server";
     private boolean useSSL,local=true,authorization=false,checkCerts=false;
+    private boolean antiCheatEnabled = true;
+    private long violationHistorySeconds = 120;
+    private List<org.betterbox.elasticBuffer.anticheat.AntiCheatThresholdRule> antiCheatThresholdRules = new ArrayList<>();
     // New variables for monitoring thresholds
     private double highMemoryUsageThreshold;
     private double lowTPSThreshold;
@@ -230,6 +235,38 @@ public class ElasticBufferConfigManager {
             plugin.getConfig().createSection("truststore_path");
             plugin.getConfig().set("truststore_path", "truststorePath");
             plugin.saveConfig();
+        }
+
+        antiCheatEnabled = plugin.getConfig().getBoolean("anti-cheat.enabled", true);
+        violationHistorySeconds = plugin.getConfig().getLong("anti-cheat.violation-history-seconds", 120L);
+        if (!plugin.getConfig().contains("anti-cheat")) {
+            elasticBufferPluginLogger.log(ElasticBufferPluginLogger.LogLevel.WARNING, "ConfigManager: anti-cheat section not fou" +
+                    "nd in config! Creating defaults.");
+            plugin.getConfig().createSection("anti-cheat");
+            plugin.getConfig().set("anti-cheat.enabled", antiCheatEnabled);
+            plugin.getConfig().set("anti-cheat.violation-history-seconds", violationHistorySeconds);
+            plugin.saveConfig();
+        }
+
+        antiCheatThresholdRules = new ArrayList<>();
+        List<Map<?, ?>> rules = plugin.getConfig().getMapList("anti-cheat.thresholds");
+        if (rules.isEmpty()) {
+            Map<String, Object> defaultRule = new HashMap<>();
+            defaultRule.put("severityMin", 5);
+            defaultRule.put("countMin", 3);
+            defaultRule.put("windowSeconds", 60);
+            defaultRule.put("command", "kick %player_name% Suspicious combat behaviour (%check_type%)");
+            plugin.getConfig().set("anti-cheat.thresholds", Collections.singletonList(defaultRule));
+            plugin.saveConfig();
+            rules = plugin.getConfig().getMapList("anti-cheat.thresholds");
+        }
+
+        for (Map<?, ?> rule : rules) {
+            double severityMin = readDouble(rule.get("severityMin"), 0);
+            int countMin = readInt(rule.get("countMin"), 1);
+            long windowSeconds = readLong(rule.get("windowSeconds"), violationHistorySeconds);
+            String command = Objects.toString(rule.get("command"), "");
+            antiCheatThresholdRules.add(new AntiCheatThresholdRule(severityMin, countMin, windowSeconds * 1000L, command));
         }
 
         truststorePassword = plugin.getConfig().getString("truststore_password");
@@ -467,6 +504,57 @@ public class ElasticBufferConfigManager {
 
     public long getMonitoringIntervalTicks() {
         return monitoringIntervalTicks;
+    }
+
+    public boolean isAntiCheatEnabled() {
+        return antiCheatEnabled;
+    }
+
+    public long getViolationHistorySeconds() {
+        return violationHistorySeconds;
+    }
+
+    public List<AntiCheatThresholdRule> getAntiCheatThresholdRules() {
+        return Collections.unmodifiableList(antiCheatThresholdRules);
+    }
+
+    private double readDouble(Object value, double defaultValue) {
+        if (value instanceof Number) {
+            return ((Number) value).doubleValue();
+        }
+        try {
+            return value != null ? Double.parseDouble(value.toString()) : defaultValue;
+        } catch (NumberFormatException ex) {
+            elasticBufferPluginLogger.log(ElasticBufferPluginLogger.LogLevel.WARNING,
+                    "ConfigManager: invalid double value in anti-cheat rule, using default " + defaultValue);
+            return defaultValue;
+        }
+    }
+
+    private int readInt(Object value, int defaultValue) {
+        if (value instanceof Number) {
+            return ((Number) value).intValue();
+        }
+        try {
+            return value != null ? Integer.parseInt(value.toString()) : defaultValue;
+        } catch (NumberFormatException ex) {
+            elasticBufferPluginLogger.log(ElasticBufferPluginLogger.LogLevel.WARNING,
+                    "ConfigManager: invalid integer value in anti-cheat rule, using default " + defaultValue);
+            return defaultValue;
+        }
+    }
+
+    private long readLong(Object value, long defaultValue) {
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        }
+        try {
+            return value != null ? Long.parseLong(value.toString()) : defaultValue;
+        } catch (NumberFormatException ex) {
+            elasticBufferPluginLogger.log(ElasticBufferPluginLogger.LogLevel.WARNING,
+                    "ConfigManager: invalid long value in anti-cheat rule, using default " + defaultValue);
+            return defaultValue;
+        }
     }
 
 }

--- a/src/main/java/org/betterbox/elasticBuffer/anticheat/AntiCheatCheck.java
+++ b/src/main/java/org/betterbox/elasticBuffer/anticheat/AntiCheatCheck.java
@@ -1,0 +1,22 @@
+package org.betterbox.elasticBuffer.anticheat;
+
+import java.util.Map;
+
+/**
+ * Contract for anti-cheat checks to allow easy extension without touching core logic.
+ */
+public interface AntiCheatCheck {
+    String getName();
+
+    CheckType getType();
+
+    /**
+     * Returns a severity value for the violation produced by this check.
+     */
+    double getDefaultSeverity();
+
+    /**
+     * Optional parameters for the check (e.g., reach distance, cps limit).
+     */
+    Map<String, Object> getParameters();
+}

--- a/src/main/java/org/betterbox/elasticBuffer/anticheat/AntiCheatManager.java
+++ b/src/main/java/org/betterbox/elasticBuffer/anticheat/AntiCheatManager.java
@@ -1,0 +1,94 @@
+package org.betterbox.elasticBuffer.anticheat;
+
+import org.betterbox.elasticBuffer.ElasticBufferConfigManager;
+import org.betterbox.elasticBuffer.ElasticBufferPluginLogger;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Coordinates registration of checks, violation tracking and reaction execution.
+ */
+public class AntiCheatManager {
+    private final Map<String, AntiCheatCheck> registeredChecks = new HashMap<>();
+    private final PlayerViolationTracker violationTracker;
+    private final ElasticBufferConfigManager configManager;
+    private final ElasticBufferPluginLogger logger;
+    private final Plugin plugin;
+    private final PlaceholderService placeholderService;
+    private List<AntiCheatThresholdRule> rules = new ArrayList<>();
+    private long historyWindowMillis;
+    private boolean enabled;
+
+    public AntiCheatManager(Plugin plugin,
+                            ElasticBufferConfigManager configManager,
+                            ElasticBufferPluginLogger logger) {
+        this(plugin, configManager, logger, new PlayerViolationTracker(), new PlaceholderService());
+    }
+
+    public AntiCheatManager(Plugin plugin,
+                            ElasticBufferConfigManager configManager,
+                            ElasticBufferPluginLogger logger,
+                            PlayerViolationTracker violationTracker,
+                            PlaceholderService placeholderService) {
+        this.plugin = plugin;
+        this.configManager = configManager;
+        this.logger = logger;
+        this.violationTracker = violationTracker;
+        this.placeholderService = placeholderService;
+        reload();
+    }
+
+    public void registerCheck(AntiCheatCheck check) {
+        registeredChecks.put(check.getName().toLowerCase(), check);
+        logger.log(ElasticBufferPluginLogger.LogLevel.DEBUG, "Registered anti-cheat check " + check.getName());
+    }
+
+    public Map<String, AntiCheatCheck> getRegisteredChecks() {
+        return Collections.unmodifiableMap(registeredChecks);
+    }
+
+    public void reload() {
+        this.enabled = configManager.isAntiCheatEnabled();
+        this.rules = new ArrayList<>(configManager.getAntiCheatThresholdRules());
+        this.historyWindowMillis = configManager.getViolationHistorySeconds() * 1000L;
+        logger.log(ElasticBufferPluginLogger.LogLevel.INFO,
+                "Anti-cheat module " + (enabled ? "enabled" : "disabled") + " with " + rules.size() + " rule(s)");
+    }
+
+    public void handleViolation(Player player, CheckType type, double severity) {
+        if (!enabled) {
+            return;
+        }
+        UUID playerId = player != null ? player.getUniqueId() : new UUID(0, 0);
+        long now = System.currentTimeMillis();
+        violationTracker.addViolation(playerId, new ViolationRecord(type, severity, now), historyWindowMillis);
+        logger.log(ElasticBufferPluginLogger.LogLevel.DEBUG,
+                "Recorded violation for " + (player != null ? player.getName() : "unknown") + " type=" + type + " severity=" + severity);
+        evaluateRules(player, playerId, type, severity);
+    }
+
+    private void evaluateRules(Player player, UUID playerId, CheckType type, double severity) {
+        for (AntiCheatThresholdRule rule : rules) {
+            long window = rule.getWindowMillis() > 0 ? rule.getWindowMillis() : historyWindowMillis;
+            int count = violationTracker.getWindowCount(playerId, window, rule.getSeverityMin());
+            if (count >= rule.getCountMin() && severity >= rule.getSeverityMin()) {
+                runCommand(rule, player, type, severity, count);
+            }
+        }
+    }
+
+    private void runCommand(AntiCheatThresholdRule rule, Player player, CheckType type, double severity, int count) {
+        String resolved = placeholderService.applyPlaceholders(rule.getCommand(), player, type, severity, count);
+        logger.log(ElasticBufferPluginLogger.LogLevel.INFO,
+                "Executing anti-cheat command for " + (player != null ? player.getName() : "unknown") + ": " + resolved);
+        Bukkit.getScheduler().runTask(plugin, () -> Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), resolved));
+    }
+}

--- a/src/main/java/org/betterbox/elasticBuffer/anticheat/AntiCheatThresholdRule.java
+++ b/src/main/java/org/betterbox/elasticBuffer/anticheat/AntiCheatThresholdRule.java
@@ -1,0 +1,34 @@
+package org.betterbox.elasticBuffer.anticheat;
+
+/**
+ * Represents a user-defined reaction rule triggered when severity and count thresholds are met.
+ */
+public class AntiCheatThresholdRule {
+    private final double severityMin;
+    private final int countMin;
+    private final long windowMillis;
+    private final String command;
+
+    public AntiCheatThresholdRule(double severityMin, int countMin, long windowMillis, String command) {
+        this.severityMin = severityMin;
+        this.countMin = countMin;
+        this.windowMillis = windowMillis;
+        this.command = command;
+    }
+
+    public double getSeverityMin() {
+        return severityMin;
+    }
+
+    public int getCountMin() {
+        return countMin;
+    }
+
+    public long getWindowMillis() {
+        return windowMillis;
+    }
+
+    public String getCommand() {
+        return command;
+    }
+}

--- a/src/main/java/org/betterbox/elasticBuffer/anticheat/CheckType.java
+++ b/src/main/java/org/betterbox/elasticBuffer/anticheat/CheckType.java
@@ -1,0 +1,11 @@
+package org.betterbox.elasticBuffer.anticheat;
+
+/**
+ * Represents the logical category of an anti-cheat check.
+ */
+public enum CheckType {
+    REACH,
+    KILLAURA,
+    VELOCITY,
+    OTHER;
+}

--- a/src/main/java/org/betterbox/elasticBuffer/anticheat/PlaceholderService.java
+++ b/src/main/java/org/betterbox/elasticBuffer/anticheat/PlaceholderService.java
@@ -1,0 +1,44 @@
+package org.betterbox.elasticBuffer.anticheat;
+
+import org.bukkit.entity.Player;
+
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Utility replacing supported placeholders in configured commands.
+ */
+public class PlaceholderService {
+    public String applyPlaceholders(String command, Player player, CheckType type, double severity, int count) {
+        if (command == null) {
+            return "";
+        }
+        Map<String, String> values = new HashMap<>();
+        values.put("%player_name%", player != null ? player.getName() : "unknown");
+        UUID uuid = player != null ? player.getUniqueId() : null;
+        values.put("%player_uuid%", uuid != null ? uuid.toString() : "unknown");
+        values.put("%check_type%", type != null ? type.name() : "UNKNOWN");
+        values.put("%severity%", Double.toString(severity));
+        values.put("%count%", Integer.toString(count));
+        values.put("%player_ip%", resolveAddress(player));
+
+        String resolved = command;
+        for (Map.Entry<String, String> entry : values.entrySet()) {
+            resolved = resolved.replace(entry.getKey(), entry.getValue());
+        }
+        return resolved;
+    }
+
+    private String resolveAddress(Player player) {
+        if (player == null) {
+            return "unknown";
+        }
+        InetSocketAddress address = player.getAddress();
+        if (address == null || address.getAddress() == null) {
+            return "unknown";
+        }
+        return address.getAddress().getHostAddress();
+    }
+}

--- a/src/main/java/org/betterbox/elasticBuffer/anticheat/PlayerViolationTracker.java
+++ b/src/main/java/org/betterbox/elasticBuffer/anticheat/PlayerViolationTracker.java
@@ -1,0 +1,81 @@
+package org.betterbox.elasticBuffer.anticheat;
+
+import java.time.Clock;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Maintains rolling violation history per player with expiration.
+ */
+public class PlayerViolationTracker {
+    private final Map<UUID, Deque<ViolationRecord>> violationsByPlayer = new HashMap<>();
+    private final Map<UUID, Integer> totalCountByPlayer = new HashMap<>();
+    private final Clock clock;
+
+    public PlayerViolationTracker() {
+        this(Clock.systemUTC());
+    }
+
+    public PlayerViolationTracker(Clock clock) {
+        this.clock = clock;
+    }
+
+    public void addViolation(UUID playerId, ViolationRecord record, long maxHistoryMillis) {
+        Deque<ViolationRecord> deque = violationsByPlayer.computeIfAbsent(playerId, uuid -> new ArrayDeque<>());
+        deque.addLast(record);
+        totalCountByPlayer.merge(playerId, 1, Integer::sum);
+        purgeExpired(deque, maxHistoryMillis);
+    }
+
+    public int getWindowCount(UUID playerId, long windowMillis, double severityMin) {
+        Deque<ViolationRecord> deque = violationsByPlayer.get(playerId);
+        if (deque == null) {
+            return 0;
+        }
+        purgeExpired(deque, windowMillis);
+        int count = 0;
+        long cutoff = clock.millis() - windowMillis;
+        for (ViolationRecord record : deque) {
+            if (record.getTimestamp() >= cutoff && record.getSeverity() >= severityMin) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    public int getTotalCount(UUID playerId) {
+        return totalCountByPlayer.getOrDefault(playerId, 0);
+    }
+
+    public List<ViolationRecord> getRecentViolations(UUID playerId, long windowMillis) {
+        Deque<ViolationRecord> deque = violationsByPlayer.get(playerId);
+        if (deque == null) {
+            return List.of();
+        }
+        purgeExpired(deque, windowMillis);
+        long cutoff = clock.millis() - windowMillis;
+        List<ViolationRecord> copy = new ArrayList<>();
+        for (ViolationRecord record : deque) {
+            if (record.getTimestamp() >= cutoff) {
+                copy.add(record);
+            }
+        }
+        return copy;
+    }
+
+    private void purgeExpired(Deque<ViolationRecord> deque, long windowMillis) {
+        if (windowMillis <= 0) {
+            deque.clear();
+            return;
+        }
+        long cutoff = clock.millis() - windowMillis;
+        while (!deque.isEmpty() && deque.peekFirst().getTimestamp() < cutoff) {
+            deque.removeFirst();
+        }
+    }
+}

--- a/src/main/java/org/betterbox/elasticBuffer/anticheat/SimpleAntiCheatCheck.java
+++ b/src/main/java/org/betterbox/elasticBuffer/anticheat/SimpleAntiCheatCheck.java
@@ -1,0 +1,45 @@
+package org.betterbox.elasticBuffer.anticheat;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * A simple immutable check definition that can be registered dynamically.
+ */
+public class SimpleAntiCheatCheck implements AntiCheatCheck {
+    private final String name;
+    private final CheckType type;
+    private final double defaultSeverity;
+    private final Map<String, Object> parameters;
+
+    public SimpleAntiCheatCheck(String name, CheckType type, double defaultSeverity) {
+        this(name, type, defaultSeverity, Collections.emptyMap());
+    }
+
+    public SimpleAntiCheatCheck(String name, CheckType type, double defaultSeverity, Map<String, Object> parameters) {
+        this.name = name;
+        this.type = type;
+        this.defaultSeverity = defaultSeverity;
+        this.parameters = parameters == null ? Collections.emptyMap() : Collections.unmodifiableMap(parameters);
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public CheckType getType() {
+        return type;
+    }
+
+    @Override
+    public double getDefaultSeverity() {
+        return defaultSeverity;
+    }
+
+    @Override
+    public Map<String, Object> getParameters() {
+        return parameters;
+    }
+}

--- a/src/main/java/org/betterbox/elasticBuffer/anticheat/ViolationRecord.java
+++ b/src/main/java/org/betterbox/elasticBuffer/anticheat/ViolationRecord.java
@@ -1,0 +1,28 @@
+package org.betterbox.elasticBuffer.anticheat;
+
+/**
+ * Represents a single violation detected by a check.
+ */
+public class ViolationRecord {
+    private final CheckType type;
+    private final double severity;
+    private final long timestamp;
+
+    public ViolationRecord(CheckType type, double severity, long timestamp) {
+        this.type = type;
+        this.severity = severity;
+        this.timestamp = timestamp;
+    }
+
+    public CheckType getType() {
+        return type;
+    }
+
+    public double getSeverity() {
+        return severity;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+}

--- a/src/main/resources/exampleFiles/config.yml
+++ b/src/main/resources/exampleFiles/config.yml
@@ -14,4 +14,17 @@ index_pattern: yourIndexPattern
 truststore_path: pathToCertFromYourElasticServer
 truststore_password: yourPassword
 
+anti-cheat:
+  enabled: true
+  violation-history-seconds: 120
+  thresholds:
+    - severityMin: 5
+      countMin: 2
+      windowSeconds: 45
+      command: "warn %player_name% [Reach] severity=%severity% count=%count%"
+    - severityMin: 7
+      countMin: 3
+      windowSeconds: 90
+      command: "kick %player_name% Excessive violations (%check_type%)"
+
 

--- a/src/test/java/org/betterbox/elasticBuffer/anticheat/PlaceholderServiceTest.java
+++ b/src/test/java/org/betterbox/elasticBuffer/anticheat/PlaceholderServiceTest.java
@@ -1,0 +1,34 @@
+package org.betterbox.elasticBuffer.anticheat;
+
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PlaceholderServiceTest {
+
+    @Test
+    void replacesBasicPlaceholders() throws Exception {
+        Player player = Mockito.mock(Player.class);
+        Mockito.when(player.getName()).thenReturn("Tester");
+        Mockito.when(player.getUniqueId()).thenReturn(UUID.fromString("00000000-0000-0000-0000-000000000001"));
+        InetSocketAddress address = new InetSocketAddress(InetAddress.getByName("192.168.0.5"), 25565);
+        Mockito.when(player.getAddress()).thenReturn(address);
+
+        PlaceholderService service = new PlaceholderService();
+        String command = service.applyPlaceholders("ban %player_name% %player_uuid% %player_ip% %check_type% %severity% %count%",
+                player, CheckType.KILLAURA, 7.5, 3);
+
+        assertTrue(command.contains("Tester"));
+        assertTrue(command.contains("00000000-0000-0000-0000-000000000001"));
+        assertTrue(command.contains("192.168.0.5"));
+        assertTrue(command.contains(CheckType.KILLAURA.name()));
+        assertTrue(command.contains("7.5"));
+        assertTrue(command.contains("3"));
+    }
+}

--- a/src/test/java/org/betterbox/elasticBuffer/anticheat/PlayerViolationTrackerTest.java
+++ b/src/test/java/org/betterbox/elasticBuffer/anticheat/PlayerViolationTrackerTest.java
@@ -1,0 +1,62 @@
+package org.betterbox.elasticBuffer.anticheat;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PlayerViolationTrackerTest {
+
+    private static class MutableClock extends Clock {
+        private long currentMillis;
+
+        MutableClock(long currentMillis) {
+            this.currentMillis = currentMillis;
+        }
+
+        public void advanceMillis(long delta) {
+            currentMillis += delta;
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneId.systemDefault();
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public long millis() {
+            return currentMillis;
+        }
+
+        @Override
+        public Instant instant() {
+            return Instant.ofEpochMilli(currentMillis);
+        }
+    }
+
+    @Test
+    void countsViolationsWithinWindow() {
+        MutableClock clock = new MutableClock(0);
+        PlayerViolationTracker tracker = new PlayerViolationTracker(clock);
+        UUID player = UUID.randomUUID();
+        long window = 60_000;
+
+        tracker.addViolation(player, new ViolationRecord(CheckType.REACH, 4.0, clock.millis()), window);
+        clock.advanceMillis(30_000);
+        tracker.addViolation(player, new ViolationRecord(CheckType.REACH, 6.0, clock.millis()), window);
+
+        assertEquals(2, tracker.getWindowCount(player, window, 0));
+
+        clock.advanceMillis(40_000);
+        assertEquals(1, tracker.getWindowCount(player, window, 5));
+    }
+}


### PR DESCRIPTION
## Summary
- add a modular anti-cheat manager with registerable checks, per-player violation tracking, and configurable threshold rules
- expand configuration and documentation to define PvP reaction commands with placeholder support
- add unit tests covering violation window logic and placeholder replacement

## Testing
- mvn test *(fails: unable to resolve maven-resources-plugin from central due to HTTP 403 in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e046193848326bbed013778dfe875)