### PR TITLE
Improve anti-cheat logging and kick aggregation

### DIFF
--- a/src/main/java/org/betterbox/elasticBuffer/ElasticBuffer.java
+++ b/src/main/java/org/betterbox/elasticBuffer/ElasticBuffer.java
@@ -63,7 +63,7 @@ public class ElasticBuffer extends JavaPlugin {
         Set<ElasticBufferPluginLogger.LogLevel> defaultLogLevels = EnumSet.of(ElasticBufferPluginLogger.LogLevel.INFO, ElasticBufferPluginLogger.LogLevel.WARNING, ElasticBufferPluginLogger.LogLevel.ERROR);
         elasticBufferPluginLogger = new ElasticBufferPluginLogger(getDataFolder().getAbsolutePath(), defaultLogLevels,this);
         elasticBufferConfigManager = new ElasticBufferConfigManager(this, elasticBufferPluginLogger, getDataFolder().getAbsolutePath());
-        antiCheatManager = new AntiCheatManager(this, elasticBufferConfigManager, elasticBufferPluginLogger);
+        antiCheatManager = new AntiCheatManager(this, elasticBufferConfigManager, elasticBufferPluginLogger, api);
         registerDefaultChecks();
         logBuffer = new LogBuffer();
         getServer().getScheduler().runTaskTimerAsynchronously(this, this::sendLogs, interval, interval);

--- a/src/main/java/org/betterbox/elasticBuffer/EventLogger.java
+++ b/src/main/java/org/betterbox/elasticBuffer/EventLogger.java
@@ -525,7 +525,9 @@ public class EventLogger implements Listener {
                 weaponUsed = attacker.getInventory().getItemInMainHand().getType().toString();
             }
 
-            processCombatChecks(event, attacker, victimEntity, distance, aimAngle);
+            Map<String, Object> combatContext = buildCombatContext(attacker, victimEntity, event, distance, aimAngle, weaponUsed, victimUUID);
+
+            processCombatChecks(event, attacker, victimEntity, distance, aimAngle, combatContext);
 
             String finalVictimName = victimName;
             String finalVictimUUID = victimUUID;
@@ -553,18 +555,7 @@ public class EventLogger implements Listener {
                         event.getEntity().getLocation().toString()
                 );
 
-                Map<String, Object> additionalFields = new HashMap<>();
-                additionalFields.put("distance", finalDistance);
-                additionalFields.put("weaponUsed", finalWeaponUsed);
-                additionalFields.put("attackerPing", attacker.getPing());
-                additionalFields.put("finalDamage", event.getFinalDamage());
-                additionalFields.put("aimAngleDegrees", finalAimAngle);
-
-                if (event.getEntity() instanceof Player) {
-                    Player victimPlayer = (Player) event.getEntity();
-                    additionalFields.put("victimPing", victimPlayer.getPing());
-                    additionalFields.put("victimUUID", finalVictimUUID);
-                }
+                Map<String, Object> additionalFields = new HashMap<>(combatContext);
 
                 api.log(
                         logMessage,
@@ -579,12 +570,36 @@ public class EventLogger implements Listener {
         }
     }
 
-    private void processCombatChecks(EntityDamageByEntityEvent event, Player attacker, LivingEntity victim, double distance, double aimAngle) {
-        handleReachCheck(attacker, victim, distance);
-        handleKillAuraChecks(event, attacker, victim, distance, aimAngle);
+    private void processCombatChecks(EntityDamageByEntityEvent event, Player attacker, LivingEntity victim, double distance, double aimAngle, Map<String, Object> combatContext) {
+        handleReachCheck(attacker, victim, distance, combatContext);
+        handleKillAuraChecks(event, attacker, victim, distance, aimAngle, combatContext);
     }
 
-    private void handleReachCheck(Player attacker, LivingEntity victim, double distance) {
+    private Map<String, Object> buildCombatContext(Player attacker, LivingEntity victim, EntityDamageByEntityEvent event, double distance, double aimAngle, String weaponUsed, String victimUUID) {
+        Map<String, Object> fields = new HashMap<>();
+        fields.put("distance", distance);
+        fields.put("weaponUsed", weaponUsed);
+        fields.put("attackerPing", attacker.getPing());
+        fields.put("finalDamage", event.getFinalDamage());
+        fields.put("aimAngleDegrees", aimAngle);
+        fields.put("attackerLocation", attacker.getLocation().toString());
+        fields.put("attackerYaw", attacker.getLocation().getYaw());
+        fields.put("attackerPitch", attacker.getLocation().getPitch());
+        fields.put("victimLocation", victim.getLocation().toString());
+        fields.put("victimType", victim.getType().toString());
+
+        if (victim instanceof Player) {
+            Player victimPlayer = (Player) victim;
+            fields.put("victimPing", victimPlayer.getPing());
+            fields.put("victimUUID", victimUUID);
+            fields.put("victimYaw", victimPlayer.getLocation().getYaw());
+            fields.put("victimPitch", victimPlayer.getLocation().getPitch());
+        }
+
+        return fields;
+    }
+
+    private void handleReachCheck(Player attacker, LivingEntity victim, double distance, Map<String, Object> combatContext) {
         double severity = 0.0;
         String reason = null;
 
@@ -597,18 +612,14 @@ public class EventLogger implements Listener {
         }
 
         if (severity > 0.0) {
-            Map<String, Object> fields = new HashMap<>();
-            fields.put("distance", distance);
-            fields.put("victimType", victim.getType().toString());
+            Map<String, Object> fields = new HashMap<>(combatContext);
             logAndHandleViolation(attacker, CheckType.REACH, severity, reason, fields);
         }
     }
 
-    private void handleKillAuraChecks(EntityDamageByEntityEvent event, Player attacker, LivingEntity victim, double distance, double aimAngle) {
+    private void handleKillAuraChecks(EntityDamageByEntityEvent event, Player attacker, LivingEntity victim, double distance, double aimAngle, Map<String, Object> combatContext) {
         if (!attacker.hasLineOfSight(victim)) {
-            Map<String, Object> fields = new HashMap<>();
-            fields.put("distance", distance);
-            fields.put("aimAngleDegrees", aimAngle);
+            Map<String, Object> fields = new HashMap<>(combatContext);
             fields.put("lineOfSight", false);
             logAndHandleViolation(attacker, CheckType.KILLAURA, configManager.getKillAuraLineOfSightSeverity(),
                     "KillAura suspicion: target not in line of sight", fields);
@@ -621,7 +632,7 @@ public class EventLogger implements Listener {
         int hitsThisTick = currentTick == lastTick ? attacksPerTick.getOrDefault(attackerId, 0) + 1 : 1;
 
         if (hitsThisTick > configManager.getKillAuraMaxHitsPerTick()) {
-            Map<String, Object> fields = new HashMap<>();
+            Map<String, Object> fields = new HashMap<>(combatContext);
             fields.put("hitsThisTick", hitsThisTick);
             fields.put("tick", currentTick);
             logAndHandleViolation(attacker, CheckType.KILLAURA, configManager.getKillAuraSameTickSeverity(),
@@ -632,7 +643,7 @@ public class EventLogger implements Listener {
         long now = System.currentTimeMillis();
         long lastTime = lastAttackTime.getOrDefault(attackerId, 0L);
         if (lastVictim != null && !lastVictim.equals(victimId) && (now - lastTime) < configManager.getKillAuraSwitchIntervalMs()) {
-            Map<String, Object> fields = new HashMap<>();
+            Map<String, Object> fields = new HashMap<>(combatContext);
             fields.put("switchIntervalMs", now - lastTime);
             fields.put("previousTarget", lastVictim.toString());
             fields.put("currentTarget", victimId.toString());
@@ -647,13 +658,13 @@ public class EventLogger implements Listener {
     }
 
     private void logAndHandleViolation(Player attacker, CheckType type, double severity, String reason, Map<String, Object> additionalFields) {
-        if (antiCheatManager != null) {
-            antiCheatManager.handleViolation(attacker, type, severity);
-        }
-
         Map<String, Object> fields = new HashMap<>(additionalFields);
         fields.put("severity", severity);
         fields.put("checkType", type.name());
+
+        if (antiCheatManager != null) {
+            antiCheatManager.handleViolation(attacker, type, severity, reason, fields);
+        }
 
         String logLevel = severity >= 7.0 ? "CHEATERS" : "WARNING";
         String playerName = attacker != null ? attacker.getName() : "N/A";

--- a/src/main/java/org/betterbox/elasticBuffer/anticheat/AntiCheatManager.java
+++ b/src/main/java/org/betterbox/elasticBuffer/anticheat/AntiCheatManager.java
@@ -1,5 +1,6 @@
 package org.betterbox.elasticBuffer.anticheat;
 
+import org.betterbox.elasticBuffer.ElasticBufferAPI;
 import org.betterbox.elasticBuffer.ElasticBufferConfigManager;
 import org.betterbox.elasticBuffer.ElasticBufferPluginLogger;
 import org.bukkit.Bukkit;
@@ -21,6 +22,7 @@ public class AntiCheatManager {
     private final PlayerViolationTracker violationTracker;
     private final ElasticBufferConfigManager configManager;
     private final ElasticBufferPluginLogger logger;
+    private final ElasticBufferAPI api;
     private final Plugin plugin;
     private final PlaceholderService placeholderService;
     private List<AntiCheatThresholdRule> rules = new ArrayList<>();
@@ -29,18 +31,21 @@ public class AntiCheatManager {
 
     public AntiCheatManager(Plugin plugin,
                             ElasticBufferConfigManager configManager,
-                            ElasticBufferPluginLogger logger) {
-        this(plugin, configManager, logger, new PlayerViolationTracker(), new PlaceholderService());
+                            ElasticBufferPluginLogger logger,
+                            ElasticBufferAPI api) {
+        this(plugin, configManager, logger, api, new PlayerViolationTracker(), new PlaceholderService());
     }
 
     public AntiCheatManager(Plugin plugin,
                             ElasticBufferConfigManager configManager,
                             ElasticBufferPluginLogger logger,
+                            ElasticBufferAPI api,
                             PlayerViolationTracker violationTracker,
                             PlaceholderService placeholderService) {
         this.plugin = plugin;
         this.configManager = configManager;
         this.logger = logger;
+        this.api = api;
         this.violationTracker = violationTracker;
         this.placeholderService = placeholderService;
         reload();
@@ -63,15 +68,15 @@ public class AntiCheatManager {
                 "Anti-cheat module " + (enabled ? "enabled" : "disabled") + " with " + rules.size() + " rule(s)");
     }
 
-    public void handleViolation(Player player, CheckType type, double severity) {
+    public void handleViolation(Player player, CheckType type, double severity, String reason, Map<String, Object> context) {
         if (!enabled) {
             return;
         }
         UUID playerId = player != null ? player.getUniqueId() : new UUID(0, 0);
         long now = System.currentTimeMillis();
-        violationTracker.addViolation(playerId, new ViolationRecord(type, severity, now), historyWindowMillis);
+        violationTracker.addViolation(playerId, new ViolationRecord(type, severity, now, reason, context), historyWindowMillis);
         logger.log(ElasticBufferPluginLogger.LogLevel.DEBUG,
-                "Recorded violation for " + (player != null ? player.getName() : "unknown") + " type=" + type + " severity=" + severity);
+                "Recorded violation for " + (player != null ? player.getName() : "unknown") + " type=" + type + " severity=" + severity + " reason=" + reason);
         evaluateRules(player, playerId, type, severity);
     }
 
@@ -89,6 +94,51 @@ public class AntiCheatManager {
         String resolved = placeholderService.applyPlaceholders(rule.getCommand(), player, type, severity, count);
         logger.log(ElasticBufferPluginLogger.LogLevel.INFO,
                 "Executing anti-cheat command for " + (player != null ? player.getName() : "unknown") + ": " + resolved);
+        logKickBundleIfNeeded(player, resolved);
         Bukkit.getScheduler().runTask(plugin, () -> Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), resolved));
+    }
+
+    private void logKickBundleIfNeeded(Player player, String resolvedCommand) {
+        if (player == null || api == null) {
+            return;
+        }
+
+        String normalized = resolvedCommand.toLowerCase();
+        boolean isKickCommand = normalized.startsWith("kick ") || normalized.contains(" kick ");
+        if (!isKickCommand) {
+            return;
+        }
+
+        String transactionId = UUID.randomUUID().toString();
+        List<ViolationRecord> recent = violationTracker.getRecentViolations(player.getUniqueId(), historyWindowMillis);
+
+        List<Map<String, Object>> violationSummaries = new ArrayList<>();
+        for (ViolationRecord record : recent) {
+            Map<String, Object> summary = new HashMap<>();
+            summary.put("type", record.getType().name());
+            summary.put("severity", record.getSeverity());
+            summary.put("timestamp", record.getTimestamp());
+            if (record.getReason() != null) {
+                summary.put("reason", record.getReason());
+            }
+            if (record.getDetails() != null && !record.getDetails().isEmpty()) {
+                summary.put("details", record.getDetails());
+            }
+            violationSummaries.add(summary);
+        }
+
+        Map<String, Object> additionalFields = new HashMap<>();
+        additionalFields.put("violations", violationSummaries);
+        additionalFields.put("command", resolvedCommand);
+
+        api.log(
+                "Player " + player.getName() + " kicked after anti-cheat violations",
+                "CHEATERS",
+                "AntiCheat",
+                transactionId,
+                player.getName(),
+                player.getUniqueId().toString(),
+                additionalFields
+        );
     }
 }

--- a/src/main/java/org/betterbox/elasticBuffer/anticheat/ViolationRecord.java
+++ b/src/main/java/org/betterbox/elasticBuffer/anticheat/ViolationRecord.java
@@ -1,5 +1,7 @@
 package org.betterbox.elasticBuffer.anticheat;
 
+import java.util.Map;
+
 /**
  * Represents a single violation detected by a check.
  */
@@ -7,11 +9,15 @@ public class ViolationRecord {
     private final CheckType type;
     private final double severity;
     private final long timestamp;
+    private final String reason;
+    private final Map<String, Object> details;
 
-    public ViolationRecord(CheckType type, double severity, long timestamp) {
+    public ViolationRecord(CheckType type, double severity, long timestamp, String reason, Map<String, Object> details) {
         this.type = type;
         this.severity = severity;
         this.timestamp = timestamp;
+        this.reason = reason;
+        this.details = details == null ? Map.of() : Map.copyOf(details);
     }
 
     public CheckType getType() {
@@ -24,5 +30,13 @@ public class ViolationRecord {
 
     public long getTimestamp() {
         return timestamp;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public Map<String, Object> getDetails() {
+        return details;
     }
 }


### PR DESCRIPTION
## Summary
- capture richer combat context when anti-cheat checks fail and include it in logs
- store violation reasons and details so anti-cheat kicks can log all failed checks together
- wire anti-cheat manager to API for bundled kick logging with a shared transaction id

## Testing
- `mvn -q -DskipTests package` *(fails: unable to download maven-resources-plugin due to 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e306008e88326be8415e2dc03d180)