### PR TITLE
Add ViolationRecord convenience constructor

### DIFF
--- a/src/main/java/org/betterbox/elasticBuffer/anticheat/ViolationRecord.java
+++ b/src/main/java/org/betterbox/elasticBuffer/anticheat/ViolationRecord.java
@@ -12,6 +12,10 @@ public class ViolationRecord {
     private final String reason;
     private final Map<String, Object> details;
 
+    public ViolationRecord(CheckType type, double severity, long timestamp) {
+        this(type, severity, timestamp, null, Map.of());
+    }
+
     public ViolationRecord(CheckType type, double severity, long timestamp, String reason, Map<String, Object> details) {
         this.type = type;
         this.severity = severity;


### PR DESCRIPTION
## Summary
- add an overload of ViolationRecord for creating records without reason or details
- keep previous usages in tests compiling by defaulting optional fields

## Testing
- mvn test *(fails: unable to download maven-resources-plugin due to 403 from repo.maven.apache.org)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e326e7a5c8326980b9007ad12e16d)